### PR TITLE
fix: update FastMCP initialization for compatibility with mcp 1.12.3

### DIFF
--- a/src/wecom_bot_mcp_server/app.py
+++ b/src/wecom_bot_mcp_server/app.py
@@ -3,26 +3,12 @@
 # Import third-party modules
 from mcp.server.fastmcp import FastMCP
 
-# Import local modules
-from wecom_bot_mcp_server import __version__
-
 # Constants
 APP_NAME = "wecom_bot_mcp_server"
 APP_DESCRIPTION = "WeCom Bot MCP Server for sending messages and files to WeCom groups."
-APP_DEPENDENCIES = [
-    "mcp>=1.3.0",
-    "notify-bridge>=0.3.0",
-    "httpx>=0.28.1",
-    "ftfy>=6.3.1",
-    "pillow>=10.2.0",
-    "platformdirs>=4.2.0",
-    "loguru>=0.7.2",
-]
 
 # Initialize FastMCP server
 mcp = FastMCP(
     name=APP_NAME,
-    description=APP_DESCRIPTION,
-    version=__version__,
-    dependencies=APP_DEPENDENCIES,
+    instructions=APP_DESCRIPTION,
 )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,9 @@
 import unittest
 from unittest.mock import patch
 
+# Import third-party modules
+import pytest
+
 # Import local modules
 from wecom_bot_mcp_server.server import main
 
@@ -23,6 +26,39 @@ class TestServer(unittest.TestCase):
         mock_setup_logging.assert_called_once()
         mock_logger.info.assert_called()  # Check that logger.info was called
         mock_mcp.run.assert_called_once()
+
+
+class TestFastMCPIntegration(unittest.TestCase):
+    """Test cases for FastMCP integration using best practices."""
+
+    def test_fastmcp_initialization(self):
+        """Test actual FastMCP initialization without mocking."""
+        # Import here to avoid import issues during module loading
+        from wecom_bot_mcp_server.app import mcp
+
+        # Test that FastMCP instance is properly initialized
+        self.assertIsNotNone(mcp)
+        self.assertEqual(mcp.name, "wecom_bot_mcp_server")
+        self.assertIsNotNone(mcp.instructions)
+
+        # Test that the instance has the expected attributes
+        self.assertTrue(hasattr(mcp, 'run'))
+        self.assertTrue(hasattr(mcp, 'name'))
+        self.assertTrue(hasattr(mcp, 'instructions'))
+
+    def test_fastmcp_no_initialization_errors(self):
+        """Test that FastMCP initialization doesn't raise errors."""
+        # This test ensures that the FastMCP API compatibility fix works
+        # and that we don't get TypeError about unexpected keyword arguments
+        try:
+            from wecom_bot_mcp_server.app import mcp
+            # If we get here without exceptions, the initialization worked
+            self.assertIsNotNone(mcp)
+        except TypeError as e:
+            if "unexpected keyword argument" in str(e):
+                self.fail(f"FastMCP initialization failed with API compatibility error: {e}")
+            else:
+                raise
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -34,6 +34,7 @@ class TestFastMCPIntegration(unittest.TestCase):
     def test_fastmcp_initialization(self):
         """Test actual FastMCP initialization without mocking."""
         # Import here to avoid import issues during module loading
+        # Import local modules
         from wecom_bot_mcp_server.app import mcp
 
         # Test that FastMCP instance is properly initialized
@@ -42,16 +43,18 @@ class TestFastMCPIntegration(unittest.TestCase):
         self.assertIsNotNone(mcp.instructions)
 
         # Test that the instance has the expected attributes
-        self.assertTrue(hasattr(mcp, 'run'))
-        self.assertTrue(hasattr(mcp, 'name'))
-        self.assertTrue(hasattr(mcp, 'instructions'))
+        self.assertTrue(hasattr(mcp, "run"))
+        self.assertTrue(hasattr(mcp, "name"))
+        self.assertTrue(hasattr(mcp, "instructions"))
 
     def test_fastmcp_no_initialization_errors(self):
         """Test that FastMCP initialization doesn't raise errors."""
         # This test ensures that the FastMCP API compatibility fix works
         # and that we don't get TypeError about unexpected keyword arguments
         try:
+            # Import local modules
             from wecom_bot_mcp_server.app import mcp
+
             # If we get here without exceptions, the initialization worked
             self.assertIsNotNone(mcp)
         except TypeError as e:


### PR DESCRIPTION
## Summary

This PR fixes FastMCP compatibility issues with the latest MCP version (1.12.3) by updating the FastMCP initialization parameters.

## Changes

### FastMCP API Updates
- Replace deprecated description parameter with instructions in FastMCP constructor
- Remove unused ersion and dependencies parameters from FastMCP initialization
- Clean up unused APP_DEPENDENCIES constant

### Test Improvements
- Add real FastMCP initialization test without mocking
- Test FastMCP API compatibility to catch future breaking changes
- Follow FastMCP testing best practices for better coverage
- Ensure tests verify actual FastMCP instance initialization

## Problem Solved

The previous code was using deprecated FastMCP API parameters:
`python
# Before (broken)
mcp = FastMCP(
    name=APP_NAME,
    description=APP_DESCRIPTION,  # ❌ Deprecated
    version=__version__,          # ❌ Not supported
    dependencies=APP_DEPENDENCIES, # ❌ Not supported
)

# After (fixed)
mcp = FastMCP(
    name=APP_NAME,
    instructions=APP_DESCRIPTION,  # ✅ Correct parameter
)
`

## Testing

- All 121 tests pass
- Added specific tests for FastMCP initialization
- Tests now catch API compatibility issues that were previously missed due to excessive mocking

## Breaking Changes

None - this is a compatibility fix that maintains the same functionality.

Fixes compatibility issue with FastMCP API changes in mcp>=1.10.0