### PR TITLE
fix: resolve auto-bump tag conflicts by syncing version numbers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "wecom-bot-mcp-server"
-version = "0.6.3"
+version = "0.6.7"
 description = "WeCom Bot MCP Server - A Python server for WeCom (WeChat Work) bot following the Model Context Protocol (MCP)"
 authors = ["longhao <hal.long@outlook.com>"]
 readme = "README.md"
@@ -45,7 +45,7 @@ Issues = "https://github.com/loonghao/wecom-bot-mcp-server/issues"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.6.3"
+version = "0.6.7"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",


### PR DESCRIPTION
## Summary

This PR fixes the auto-bump tag conflict issue where the system tried to create an already existing tag `v0.6.4`.

## Problem

The auto-bump process failed with:
```
fatal: tag 'v0.6.4' already exists
```

This happened because version numbers were out of sync across different files:
- `pyproject.toml`: version `0.6.3` 
- `__version__.py`: version `0.6.7`
- `smithery.yaml`: version `0.6.7`
- Remote tags: already up to `v0.6.7`

## Solution

Synchronized all version numbers to `0.6.7`:
- ✅ Updated `pyproject.toml` version from `0.6.3` to `0.6.7`
- ✅ Updated commitizen version from `0.6.3` to `0.6.7`
- ✅ Aligned with existing `__version__.py` (already `0.6.7`)
- ✅ Aligned with existing `smithery.yaml` (already `0.6.7`)

## Changes

- `pyproject.toml`: Updated version fields to `0.6.7`

## Testing

- Version numbers are now consistent across all files
- Auto-bump should work correctly for future releases starting from `0.6.7`

## Breaking Changes

None - this is a version synchronization fix.

Fixes the auto-bump tag conflict issue.