### PR TITLE
Fix send_wecom_image param and improve MCP prompts (Fixes #104)

### DIFF
--- a/src/wecom_bot_mcp_server/image.py
+++ b/src/wecom_bot_mcp_server/image.py
@@ -214,7 +214,7 @@ async def _send_image_to_wecom(image_path: Path, base_url: str) -> Any:
             "wecom",
             webhook_url=base_url,
             msg_type="image",
-            image=str(image_path.absolute()),
+            image_path=str(image_path.absolute()),
         )
 
         return response

--- a/src/wecom_bot_mcp_server/message.py
+++ b/src/wecom_bot_mcp_server/message.py
@@ -83,7 +83,10 @@ def get_markdown_capabilities_resource() -> str:
         "- If the main content is a standalone image file or screenshot, "
         "send it with the send_wecom_image tool (msg_type=image).\n"
         "- If the image is just an illustration inside a larger report, "
-        "use markdown_v2 and embed it with ![alt](url).\n"
+        "use markdown_v2 and embed it with ![alt](url).\n\n"
+        "## File sending recommendations\n"
+        "- Use the send_wecom_file tool when sending non-image files such as "
+        "reports, logs, or archives.\n"
     )
 
 
@@ -103,6 +106,8 @@ def wecom_message_guidelines() -> str:
         "- Do not request `text` or legacy `markdown` msg_type; they will be rejected as invalid.\n"
         "- If the main content is an image file (local path or URL), "
         "call the `send_wecom_image` tool instead of embedding it in markdown.\n"
+        "- If the user asks to send a non-image file (reports, logs, archives), "
+        "call the `send_wecom_file` tool with the local file path.\n"
         "- URLs must be preserved exactly; do not change underscores or other "
         "characters inside URLs.\n"
     )

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -172,7 +172,7 @@ async def test_send_wecom_image_url(mock_image_download, fs):
             "wecom",
             webhook_url="https://example.com/webhook",
             msg_type="image",
-            image=str(downloaded_path.absolute()),
+            image_path=str(downloaded_path.absolute()),
         )
 
 
@@ -342,7 +342,7 @@ async def test_send_image_to_wecom(fs):
             "wecom",
             webhook_url=base_url,
             msg_type="image",
-            image=str(image_path.absolute()),
+            image_path=str(image_path.absolute()),
         )
 
 


### PR DESCRIPTION
Fixes #104.

- Fix NotifyBridge call in `send_wecom_image` to pass `image_path` instead of `image`
- Update tests to assert against the correct parameter name
- Enhance MCP prompts to better explain when/how to use `send_wecom_image` and `send_wecom_file` for images and files

Note: pytest is not available in the current environment, so tests were not executed locally in this run.