### PR TITLE
fix: use correct 'content' parameter for notify-bridge wecom API

### DIFF
--- a/src/wecom_bot_mcp_server/message.py
+++ b/src/wecom_bot_mcp_server/message.py
@@ -297,7 +297,7 @@ async def _send_message_to_wecom(
                 "wecom",
                 webhook_url=base_url,
                 msg_type=msg_type,
-                message=content,
+                content=content,
                 mentioned_list=mentioned_list or [],
                 mentioned_mobile_list=mentioned_mobile_list or [],
             )

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -65,7 +65,7 @@ async def test_send_message(mock_get_webhook_url, mock_notify_bridge):
         "wecom",
         webhook_url="https://example.com/webhook",
         msg_type="markdown_v2",
-        message="Test message",
+        content="Test message",
         mentioned_list=[],
         mentioned_mobile_list=[],
     )
@@ -291,7 +291,7 @@ async def test_send_message_to_wecom(mock_notify_bridge):
         "wecom",
         webhook_url="https://example.com/webhook",
         msg_type="markdown_v2",
-        message="Test message",
+        content="Test message",
         mentioned_list=["user1"],
         mentioned_mobile_list=["13800138000"],
     )


### PR DESCRIPTION
## Problem

The `send_message` tool was failing with WeCom API error: `empty content`.

## Root Cause

In commit `c15cb3e` ("feat: enforce markdown_v2 only for WeCom messages"), the code was refactored from dict-style parameters to keyword arguments. During this refactoring, the parameter name was incorrectly changed from `content` to `message`.

**Before (working):**
```python
return await nb.send_async(
    "wecom",
    {
        "base_url": base_url,
        "msg_type": msg_type,
        "content": content,  # correct
        ...
    },
)
```

**After (broken):**
```python
return await nb.send_async(
    "wecom",
    webhook_url=base_url,
    msg_type=msg_type,
    message=content,  # wrong parameter name!
    ...
)
```

## Solution

Change `message=content` to `content=content` to match the notify-bridge API.

## Verification

Confirmed via [notify-bridge documentation](https://context7.com/loonghao/notify-bridge) that the correct parameter name is `content`.

## Impact

- Only `send_message` was affected
- Other interfaces (`send_image`, `send_file`, `template_card`) are working correctly