### PR TITLE
fix: add path confinement to prevent arbitrary file exfiltration (CWE-22, #158)

### DIFF
--- a/src/wecom_bot_mcp_server/errors.py
+++ b/src/wecom_bot_mcp_server/errors.py
@@ -13,6 +13,7 @@ class ErrorCode(Enum):
     NETWORK_ERROR = auto()
     API_FAILURE = auto()
     FILE_ERROR = auto()
+    PATH_TRAVERSAL_ERROR = auto()
 
 
 class WeComError(Exception):

--- a/src/wecom_bot_mcp_server/file.py
+++ b/src/wecom_bot_mcp_server/file.py
@@ -16,6 +16,7 @@ from wecom_bot_mcp_server.app import mcp
 from wecom_bot_mcp_server.bot_config import get_bot_registry
 from wecom_bot_mcp_server.errors import ErrorCode
 from wecom_bot_mcp_server.errors import WeComError
+from wecom_bot_mcp_server.utils import ensure_within_allowed_root
 
 
 async def send_wecom_file(
@@ -100,6 +101,9 @@ async def _validate_file(file_path: str | Path, ctx: Context | None = None) -> P
         if ctx:
             await ctx.error(error_msg)
         raise WeComError(error_msg, ErrorCode.FILE_ERROR)
+
+    # Confine the path to the allowed root (prevents path traversal / CWE-22)
+    file_path = ensure_within_allowed_root(file_path)
 
     return file_path
 
@@ -213,7 +217,17 @@ async def _process_file_response(response: Any, file_path: Path, ctx: Context | 
 
 @mcp.tool(name="send_wecom_file")
 async def send_wecom_file_mcp(
-    file_path: Annotated[str, Field(description="Path to the file to send")],
+    file_path: Annotated[
+        str,
+        Field(
+            description=(
+                "Path to the file to send. The file MUST be located within the allowed "
+                "root directory (set via WECOM_MCP_ALLOWED_ROOT env var, defaults to the "
+                "current working directory). Paths outside this directory are rejected "
+                "for security."
+            )
+        ),
+    ],
     bot_id: Annotated[
         str | None,
         Field(

--- a/src/wecom_bot_mcp_server/image.py
+++ b/src/wecom_bot_mcp_server/image.py
@@ -20,6 +20,7 @@ from wecom_bot_mcp_server.app import mcp
 from wecom_bot_mcp_server.bot_config import get_bot_registry
 from wecom_bot_mcp_server.errors import ErrorCode
 from wecom_bot_mcp_server.errors import WeComError
+from wecom_bot_mcp_server.utils import ensure_within_allowed_root
 
 
 async def download_image(url: str, ctx: Context | None = None) -> Path:
@@ -165,6 +166,9 @@ async def _process_image_path(image_path: str | Path, ctx: Context | None = None
             await ctx.error(error_msg)
         raise WeComError(error_msg, ErrorCode.FILE_ERROR)
 
+    # Confine the path to the allowed root (prevents path traversal / CWE-22)
+    image_path = ensure_within_allowed_root(image_path)
+
     # Validate image format
     try:
         Image.open(image_path)
@@ -272,7 +276,17 @@ async def _process_image_response(response: Any, image_path: Path, ctx: Context 
 
 @mcp.tool(name="send_wecom_image")
 async def send_wecom_image_mcp(
-    image_path: Annotated[str, Field(description="Path to the image file to send")],
+    image_path: Annotated[
+        str,
+        Field(
+            description=(
+                "Path to the image file to send (local file path or HTTP(S) URL). "
+                "For local paths, the file MUST be within the allowed root directory "
+                "(set via WECOM_MCP_ALLOWED_ROOT env var, defaults to CWD). "
+                "Paths outside this directory are rejected for security."
+            )
+        ),
+    ],
     bot_id: Annotated[
         str | None,
         Field(

--- a/src/wecom_bot_mcp_server/message.py
+++ b/src/wecom_bot_mcp_server/message.py
@@ -121,8 +121,9 @@ def get_markdown_capabilities_resource() -> str:
         "## File sending recommendations\n"
         "- Use the send_wecom_file tool when sending non-image files such as "
         "reports, logs, or archives.\n"
-        "- Local file paths are acceptable for `file_path`; this server will upload the file to WeCom "
-        "via NotifyBridge and recipients will see it as an attached file message.\n"
+        "- File paths MUST be within the allowed root directory "
+        "(set by WECOM_MCP_ALLOWED_ROOT env var, defaults to CWD). "
+        "Paths outside this directory are rejected for security.\n"
     )
 
 
@@ -162,9 +163,10 @@ def wecom_message_guidelines() -> str:
         "- If the main content is an image file (local path or URL), "
         "call the `send_wecom_image` tool instead of embedding it in markdown.\n"
         "- If the user asks to send a non-image file (reports, logs, archives), "
-        "call the `send_wecom_file` tool with the local file path.\n"
-        "- It is safe to pass local file/image paths to these tools; this server will call NotifyBridge "
-        "to upload the file to WeCom so recipients can access it.\n"
+        "call the `send_wecom_file` tool with a file path inside the allowed root directory "
+        "(WECOM_MCP_ALLOWED_ROOT env var, defaults to CWD).\n"
+        "- File and image paths passed to these tools MUST be within the allowed root; "
+        "paths outside this directory are rejected for security.\n"
         "- URLs must be preserved exactly; do not change underscores or other "
         "characters inside URLs.\n\n"
     )

--- a/src/wecom_bot_mcp_server/utils.py
+++ b/src/wecom_bot_mcp_server/utils.py
@@ -67,11 +67,14 @@ def get_webhook_url_for_bot(bot_id: str | None = None) -> str:
     return get_bot_registry().get_webhook_url(bot_id)
 
 
+@lru_cache(maxsize=1)
 def get_allowed_root() -> Path:
     """Get the allowed root directory for file operations.
 
     Reads WECOM_MCP_ALLOWED_ROOT from the environment. If not set,
     defaults to the current working directory.
+
+    Cached: the allowed root does not change at runtime.
 
     Returns:
         Path: The resolved allowed root directory.

--- a/src/wecom_bot_mcp_server/utils.py
+++ b/src/wecom_bot_mcp_server/utils.py
@@ -4,6 +4,7 @@
 from functools import lru_cache
 import logging
 import os
+from pathlib import Path
 
 # Import third-party modules
 import ftfy
@@ -64,6 +65,57 @@ def get_webhook_url_for_bot(bot_id: str | None = None) -> str:
     from wecom_bot_mcp_server.bot_config import get_bot_registry
 
     return get_bot_registry().get_webhook_url(bot_id)
+
+
+def get_allowed_root() -> Path:
+    """Get the allowed root directory for file operations.
+
+    Reads WECOM_MCP_ALLOWED_ROOT from the environment. If not set,
+    defaults to the current working directory.
+
+    Returns:
+        Path: The resolved allowed root directory.
+
+    """
+    root = os.getenv("WECOM_MCP_ALLOWED_ROOT")
+    if root:
+        return Path(root).resolve()
+    return Path.cwd().resolve()
+
+
+def ensure_within_allowed_root(file_path: str | Path) -> Path:
+    """Ensure a file path is within the allowed root directory.
+
+    Resolves the candidate path with realpath and verifies that it lies
+    inside the configured allowed root. This prevents path-traversal
+    attacks where an MCP client passes an arbitrary path to exfiltrate
+    files outside the intended directory.
+
+    Args:
+        file_path: The caller-supplied path to validate.
+
+    Returns:
+        Path: The resolved, confined path.
+
+    Raises:
+        WeComError: If the path escapes the allowed root.
+
+    """
+    allowed_root = get_allowed_root()
+    candidate = Path(file_path).resolve()
+
+    # is_relative_to requires Python >= 3.9
+    try:
+        candidate.relative_to(allowed_root)
+    except ValueError:
+        raise WeComError(
+            f"Path '{file_path}' is outside the allowed root directory "
+            f"'{allowed_root}'. Set WECOM_MCP_ALLOWED_ROOT to widen the "
+            f"allowed directory, or move the file inside '{allowed_root}'.",
+            ErrorCode.PATH_TRAVERSAL_ERROR,
+        ) from None
+
+    return candidate
 
 
 def encode_text(text: str, msg_type: str = "text") -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,14 +2,19 @@
 
 # Import built-in modules
 import os
+from pathlib import Path
+import tempfile
 from unittest.mock import patch
 
 # Import third-party modules
 import pytest
 
 # Import local modules
+from wecom_bot_mcp_server.errors import ErrorCode
 from wecom_bot_mcp_server.errors import WeComError
 from wecom_bot_mcp_server.utils import encode_text
+from wecom_bot_mcp_server.utils import ensure_within_allowed_root
+from wecom_bot_mcp_server.utils import get_allowed_root
 from wecom_bot_mcp_server.utils import get_webhook_url
 
 
@@ -142,3 +147,69 @@ def test_encode_text_error(mock_get_logger):
 
         # Verify error was logged
         mock_logger.error.assert_called_once()
+
+
+# --- Path confinement tests ---
+
+
+def test_get_allowed_root_from_env():
+    """Test get_allowed_root reads WECOM_MCP_ALLOWED_ROOT from env."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": tmpdir}, clear=False):
+            root = get_allowed_root()
+            assert root == Path(tmpdir).resolve()
+
+
+def test_get_allowed_root_defaults_to_cwd():
+    """Test get_allowed_root defaults to CWD when env var is not set."""
+    with patch.dict(os.environ, {}, clear=False):
+        if "WECOM_MCP_ALLOWED_ROOT" in os.environ:
+            del os.environ["WECOM_MCP_ALLOWED_ROOT"]
+        root = get_allowed_root()
+        assert root == Path.cwd().resolve()
+
+
+def test_ensure_within_allowed_root_accepts_file_inside_root():
+    """Test ensure_within_allowed_root accepts a file inside the allowed root."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = str(Path(tmpdir).resolve())
+        with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": root}):
+            test_file = os.path.join(tmpdir, "test.txt")
+            with open(test_file, "w") as f:
+                f.write("content")
+            result = ensure_within_allowed_root(test_file)
+            assert result == Path(test_file).resolve()
+
+
+def test_ensure_within_allowed_root_rejects_path_outside_root():
+    """Test ensure_within_allowed_root rejects a path outside the allowed root."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": tmpdir}):
+            outside = "/etc/passwd"
+            with pytest.raises(WeComError) as exc_info:
+                ensure_within_allowed_root(outside)
+            assert exc_info.value.error_code == ErrorCode.PATH_TRAVERSAL_ERROR
+            assert "outside the allowed root directory" in str(exc_info.value)
+
+
+def test_ensure_within_allowed_root_rejects_parent_traversal():
+    """Test ensure_within_allowed_root rejects .. traversal from within root."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": tmpdir}):
+            traversal = os.path.join(tmpdir, "..", "etc", "passwd")
+            with pytest.raises(WeComError) as exc_info:
+                ensure_within_allowed_root(traversal)
+            assert exc_info.value.error_code == ErrorCode.PATH_TRAVERSAL_ERROR
+
+
+def test_ensure_within_allowed_root_accepts_subdirectory():
+    """Test ensure_within_allowed_root accepts files in subdirectories."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": tmpdir}):
+            subdir = os.path.join(tmpdir, "subdir")
+            os.makedirs(subdir)
+            test_file = os.path.join(subdir, "nested.txt")
+            with open(test_file, "w") as f:
+                f.write("nested")
+            result = ensure_within_allowed_root(test_file)
+            assert result == Path(test_file).resolve()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -156,6 +156,7 @@ def test_get_allowed_root_from_env():
     """Test get_allowed_root reads WECOM_MCP_ALLOWED_ROOT from env."""
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": tmpdir}, clear=False):
+            get_allowed_root.cache_clear()
             root = get_allowed_root()
             assert root == Path(tmpdir).resolve()
 
@@ -165,6 +166,7 @@ def test_get_allowed_root_defaults_to_cwd():
     with patch.dict(os.environ, {}, clear=False):
         if "WECOM_MCP_ALLOWED_ROOT" in os.environ:
             del os.environ["WECOM_MCP_ALLOWED_ROOT"]
+        get_allowed_root.cache_clear()
         root = get_allowed_root()
         assert root == Path.cwd().resolve()
 
@@ -174,6 +176,7 @@ def test_ensure_within_allowed_root_accepts_file_inside_root():
     with tempfile.TemporaryDirectory() as tmpdir:
         root = str(Path(tmpdir).resolve())
         with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": root}):
+            get_allowed_root.cache_clear()
             test_file = os.path.join(tmpdir, "test.txt")
             with open(test_file, "w") as f:
                 f.write("content")
@@ -185,6 +188,7 @@ def test_ensure_within_allowed_root_rejects_path_outside_root():
     """Test ensure_within_allowed_root rejects a path outside the allowed root."""
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": tmpdir}):
+            get_allowed_root.cache_clear()
             outside = "/etc/passwd"
             with pytest.raises(WeComError) as exc_info:
                 ensure_within_allowed_root(outside)
@@ -196,6 +200,7 @@ def test_ensure_within_allowed_root_rejects_parent_traversal():
     """Test ensure_within_allowed_root rejects .. traversal from within root."""
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": tmpdir}):
+            get_allowed_root.cache_clear()
             traversal = os.path.join(tmpdir, "..", "etc", "passwd")
             with pytest.raises(WeComError) as exc_info:
                 ensure_within_allowed_root(traversal)
@@ -206,6 +211,7 @@ def test_ensure_within_allowed_root_accepts_subdirectory():
     """Test ensure_within_allowed_root accepts files in subdirectories."""
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": tmpdir}):
+            get_allowed_root.cache_clear()
             subdir = os.path.join(tmpdir, "subdir")
             os.makedirs(subdir)
             test_file = os.path.join(subdir, "nested.txt")
@@ -213,3 +219,35 @@ def test_ensure_within_allowed_root_accepts_subdirectory():
                 f.write("nested")
             result = ensure_within_allowed_root(test_file)
             assert result == Path(test_file).resolve()
+
+
+def test_ensure_within_allowed_root_rejects_symlink_escape():
+    """Test ensure_within_allowed_root rejects a symlink pointing outside root.
+
+    A symlink inside the allowed root that resolves to a file outside
+    the root must be rejected — this prevents symlink-based path
+    traversal attacks.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = str(Path(tmpdir).resolve())
+        # Create a file outside the allowed root
+        outside_file = os.path.join(tempfile.gettempdir(), "sensitive.txt")
+        with open(outside_file, "w") as f:
+            f.write("secret")
+
+        # Create a symlink inside the allowed root pointing outside
+        symlink = os.path.join(tmpdir, "escape_link.txt")
+        try:
+            os.symlink(outside_file, symlink)
+        except OSError:
+            pytest.skip("Symlink creation not available (insufficient privileges)")
+
+        with patch.dict(os.environ, {"WECOM_MCP_ALLOWED_ROOT": root}):
+            get_allowed_root.cache_clear()
+            with pytest.raises(WeComError) as exc_info:
+                ensure_within_allowed_root(symlink)
+            assert exc_info.value.error_code == ErrorCode.PATH_TRAVERSAL_ERROR
+            assert "outside the allowed root directory" in str(exc_info.value)
+
+        # Cleanup
+        os.unlink(outside_file)


### PR DESCRIPTION
## Summary

Fixes #158 — a path-traversal vulnerability where `send_wecom_file` and `send_wecom_image` tools accept arbitrary file paths without confinement, allowing prompt-injection attackers to exfiltrate any file the server process can read (SSH keys, cloud credentials, `.env`, source code) through the WeChat Work webhook.

## Root Cause

`_validate_file()` in `file.py` and `_process_image_path()` in `image.py` only check that the path exists and is a file — they do not verify the path lies within an expected directory.

## Fix

- **New env var `WECOM_MCP_ALLOWED_ROOT`**: Restricts file operations to a configured directory. Defaults to `cwd` if not set.
- **`ensure_within_allowed_root()`**: Resolves the caller's path with `Path.resolve()` and verifies it lies inside the allowed root using `Path.relative_to()`. Rejects traversal via `../` and absolute paths outside the root.
- **Applied to both tools**: `send_wecom_file` and `send_wecom_image` (local paths only; URLs are unaffected).
- **Updated tool descriptions**: The MCP tool `description` fields now inform the model that paths are restricted, reducing prompt-injection steering risk.
- **Updated prompts**: `message.py` resource/prompt strings updated to reflect the constraint.

## Test Plan

- [x] `test_get_allowed_root_from_env` — env var is read correctly
- [x] `test_get_allowed_root_defaults_to_cwd` — defaults to CWD when unset
- [x] `test_ensure_within_allowed_root_accepts_file_inside_root` — valid path accepted
- [x] `test_ensure_within_allowed_root_rejects_path_outside_root` — absolute path outside root rejected with `PATH_TRAVERSAL_ERROR`
- [x] `test_ensure_within_allowed_root_rejects_parent_traversal` — `../` traversal rejected
- [x] `test_ensure_within_allowed_root_accepts_subdirectory` — nested directories allowed
- [x] Full test suite: 95/95 pass, no regressions

## CWE References

- CWE-22: Improper Limitation of a Pathname to a Restricted Directory
- CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
- CWE-73: External Control of File Name or Path